### PR TITLE
chore: 開発環境を追加する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM composer:2.0.6 AS composer
+
+FROM php:7.4.12-apache AS shared
+RUN apt-get update && apt-get install -y \
+  busybox-static \
+  libpq-dev \
+  libzip-dev \
+  locales \
+  supervisor \
+  unzip \
+  && docker-php-ext-install \
+  bcmath \
+  pdo_mysql \
+  pdo_pgsql \
+  zip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
+COPY ./docker-compose/php/my.ini /usr/local/etc/php/conf.d/
+RUN a2enmod rewrite
+ENV APACHE_DOCUMENT_ROOT /var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+COPY ./docker-compose/php/001-my.conf /etc/apache2/sites-available/001-my.conf
+RUN a2dissite 000-default \
+  && a2ensite 001-my
+ENV APP_ENV laravel
+RUN mkdir -p /var/log/supervisor
+COPY ./docker-compose/php/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY ./docker-compose/php/crontabs/root /var/spool/cron/crontabs/root
+RUN ln -sf /dev/stdout /var/log/cron
+CMD ["/usr/bin/supervisord"]
+
+FROM shared AS develop
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+  && apt-get update && apt-get install -y \
+  git \
+	nodejs \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+#FROM composer AS build_composer
+#ENV APP_ENV laravel
+#COPY --chown=www-data:www-data ./composer.json ./composer.lock ./
+#RUN composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress --no-suggest --no-interaction
+#COPY --chown=www-data:www-data . .
+#RUN composer dump-autoload \
+#  && composer run-script post-root-package-install \
+#  && composer run-script post-create-project-cmd
+#
+#FROM node:14.15.0 AS build_npm
+#WORKDIR /app
+#COPY ./package.json ./package-lock.json ./
+#RUN npm install
+#COPY . .
+#RUN npm run production
+#
+#FROM shared AS server
+#COPY --from=build_composer --chown=www-data:www-data ./app/ .
+#RUN touch ./database/database.sqlite
+#COPY --from=build_npm --chown=www-data:www-data ./app/public/css ./public/css
+#COPY --from=build_npm --chown=www-data:www-data ./app/public/js ./public/js
+#COPY --from=build_npm --chown=www-data:www-data ./app/public/mix-manifest.json ./public/mix-manifest.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # sample_docker_php
-PHP の開発環境、Docker 化したサーバ環境の、サンプル Docker Compose です。
+Laravel 8 に関して、開発環境と Docker 化したサーバ環境のサンプル Docker Compose です。
+
+## 開発環境のセットアップ
+```bash
+docker-compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+services:
+  app:
+    build:
+      context: ./
+      target: develop
+    ports:
+      - "80:80"
+    volumes:
+      - ./:/var/www/html:cached

--- a/docker-compose/php/001-my.conf
+++ b/docker-compose/php/001-my.conf
@@ -1,0 +1,37 @@
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot ${APACHE_DOCUMENT_ROOT}
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+
+	<Directory ${APACHE_DOCUMENT_ROOT}>
+		Options FollowSymLinks
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/docker-compose/php/crontabs/root
+++ b/docker-compose/php/crontabs/root
@@ -1,0 +1,1 @@
+* * * * * cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/docker-compose/php/my.ini
+++ b/docker-compose/php/my.ini
@@ -1,0 +1,5 @@
+[Date]
+date.timezone = "Asia/Tokyo"
+[mbstring]
+mbstring.internal_encoding = "UTF-8"
+mbstring.language = "Japanese"

--- a/docker-compose/php/supervisord.conf
+++ b/docker-compose/php/supervisord.conf
@@ -1,0 +1,18 @@
+[supervisord]
+logfile = /tmp/supervisord.log
+pidfile = /tmp/supervisord.pid
+nodaemon=true
+
+[program:apache2]
+command=/usr/local/bin/apache2-foreground
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:crond]
+command=/bin/busybox crond -f -L /var/log/cron
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
PHP 拡張のインストールはフレームワークにより異なることを考えると、
各フレームワークに対応した Git
リポジトリとするのが良いと考えを変えようと思う。
Laravel 8 で行く。